### PR TITLE
Reorganize index.js to allow for a couple optimizations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserifyi18n",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Browserify transform for internationalizing tagged strings",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- remove _.template, replace with while loop for string-escape safety
- handle default language by using empty catalog instead of explicit kickout
- kick out of translating non-translatable extentions immediately in i18n/fast exports
